### PR TITLE
v2.1.3

### DIFF
--- a/SNRHos/FNRH_DIGITAL/Reservas/Hospedes.cs
+++ b/SNRHos/FNRH_DIGITAL/Reservas/Hospedes.cs
@@ -85,9 +85,9 @@ namespace SNRHos.FNRH_DIGITAL.Reservas
         public string NomeResponsavel { get; set; }
 
         [JsonProperty("checkin_em")]
-        public DateTime CheckinEm { get; set; }
+        public DateTime? CheckinEm { get; set; }
 
         [JsonProperty("checkout_em")]
-        public DateTime CheckoutEm { get; set; }
+        public DateTime? CheckoutEm { get; set; }
     }
 }

--- a/SNRHos/SNRHos.csproj
+++ b/SNRHos/SNRHos.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>SNRHos</PackageId>
-    <Version>2.1.2</Version>
+    <Version>2.1.3</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
#### PR Classification
Alteração de API para permitir valores nulos em datas de check-in e check-out, além de atualização de versão do pacote.

#### PR Summary
Os campos de data de check-in e check-out na classe Hospedes agora aceitam valores nulos, tornando-os opcionais. A versão do pacote foi incrementada.
- Hospedes.cs: alteração dos tipos dos campos CheckinEm e CheckoutEm de DateTime para DateTime?.
- SNRHos.csproj: atualização da versão do pacote de 2.1.2 para 2.1.3.
