### PR TITLE
v.2.1.4

### DIFF
--- a/SNRHos/FNRH_DIGITAL/Pessoas/Pessoas.cs
+++ b/SNRHos/FNRH_DIGITAL/Pessoas/Pessoas.cs
@@ -83,7 +83,7 @@ namespace SNRHos.FNRH.Pessoas
         public string PaisResidenciaId { get; set; }
 
         [JsonProperty("cidade_id")]
-        public long CidadeId { get; set; }
+        public long? CidadeId { get; set; }
 
         [JsonProperty("estado_id")]
         public string EstadoId { get; set; }

--- a/SNRHos/SNRHos.csproj
+++ b/SNRHos/SNRHos.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>SNRHos</PackageId>
-    <Version>2.1.3</Version>
+    <Version>2.1.4</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
#### PR Classification
Alteração de API para permitir valores nulos em propriedade e atualização de versão do pacote.

#### PR Summary
A propriedade CidadeId foi tornada opcional na classe Pessoas e a versão do pacote foi incrementada.
- Pessoas.cs: alteração do tipo da propriedade CidadeId de long para long? (nullable)
- SNRHos.csproj: atualização da versão do pacote de 2.1.3 para 2.1.4
